### PR TITLE
Badges on readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,8 @@
 # Java Compiler
 
-![Build status](
-https://codebuild.us-east-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiZlQycVNFMGV4NEdDOGI4MWo1TDBFVXFERWdVZk80WCtGUnV1MHZtcmQvRVlXQ0g3eCtvaDlsK3FwRVRNQjF0Zm5GVHdSTDlNaU5hbWQ1ZmNqMGdyN3hBPSIsIml2UGFyYW1ldGVyU3BlYyI6IjVHWHdEY09EZjlicVlYUUYiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master
-)
+![Build status](https://codebuild.us-east-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiZlQycVNFMGV4NEdDOGI4MWo1TDBFVXFERWdVZk80WCtGUnV1MHZtcmQvRVlXQ0g3eCtvaDlsK3FwRVRNQjF0Zm5GVHdSTDlNaU5hbWQ1ZmNqMGdyN3hBPSIsIml2UGFyYW1ldGVyU3BlYyI6IjVHWHdEY09EZjlicVlYUUYiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
 
-![Coverage report](
-https://s3.amazonaws.com/java-compiler-badges/coverage-report.svg
-)
+![Coverage report](https://s3.amazonaws.com/java-compiler-badges/coverage-report.svg)
 
 This is a Java program used to compile Java files into native code.
 Instead of using a complete java library implementation, this uses the Java Native Interface for calling

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Java Compiler
 
-![Build status](https://codebuild.us-east-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiZlQycVNFMGV4NEdDOGI4MWo1TDBFVXFERWdVZk80WCtGUnV1MHZtcmQvRVlXQ0g3eCtvaDlsK3FwRVRNQjF0Zm5GVHdSTDlNaU5hbWQ1ZmNqMGdyN3hBPSIsIml2UGFyYW1ldGVyU3BlYyI6IjVHWHdEY09EZjlicVlYUUYiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
-
-![Coverage report](https://s3.amazonaws.com/java-compiler-badges/coverage-report.svg)
+<p>
+    AWS Linux build details:
+    <img src="https://codebuild.us-east-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiZlQycVNFMGV4NEdDOGI4MWo1TDBFVXFERWdVZk80WCtGUnV1MHZtcmQvRVlXQ0g3eCtvaDlsK3FwRVRNQjF0Zm5GVHdSTDlNaU5hbWQ1ZmNqMGdyN3hBPSIsIml2UGFyYW1ldGVyU3BlYyI6IjVHWHdEY09EZjlicVlYUUYiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master" alt="aws build status"/>
+    <img src="https://s3.amazonaws.com/java-compiler-badges/coverage-report.svg" alt="aws coverage number" />
+</p>
 
 This is a Java program used to compile Java files into native code.
 Instead of using a complete java library implementation, this uses the Java Native Interface for calling

--- a/buildspec-linux-merged.yaml
+++ b/buildspec-linux-merged.yaml
@@ -35,7 +35,7 @@ phases:
       # generate the template
       - sed -e '/NUM/{r coverage.txt' -e 'd}' coverage-template.svg > coverage-report.svg
       # upload template to s3
-      - aws s3 cp coverage-report.svg s3://java-compiler-badges
+      - aws s3 cp coverage-report.svg s3://java-compiler-badges --metadata-directive REPLACE --cache-control max-age=0
       - aws s3api put-object-acl --bucket java-compiler-badges --key coverage-report.svg --acl public-read
 
 #artifacts:

--- a/coverage-template.svg
+++ b/coverage-template.svg
@@ -1,21 +1,21 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100" height="20">
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="20">
     <clipPath id="button">
-        <rect width="100" height="20" rx="3" fill="#fff" />
+        <rect width="120" height="20" rx="5" fill="#fff" />
     </clipPath>
     <linearGradient id="light" x2="0" y2="100%">
         <stop offset="0" stop-color="#bbb" stop-opacity=".1" />
         <stop offset="1" stop-opacity=".1" />
     </linearGradient>
     <g clip-path="url(#button)">
-        <rect width="100" height="20" fill="#555" />
-        <rect x="60" width="40" height="20" fill="#4c1" />
-        <rect width="100" height="20" fill="url(#light)" />
+        <rect width="120" height="20" fill="#555" />
+        <rect x="60" width="60" height="20" fill="#4c1" />
+        <rect width="120" height="20" fill="url(#light)" />
     </g>
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif"
        font-size="11">
         <text x="30" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="30" y="14">coverage</text>
-        <text x="80" y="14">
+        <text x="90" y="14">
             NUM
             %
         </text>


### PR DESCRIPTION
Improved coverage svg.
Since images are cached, have to send cache control header from AWS to make it always load the latest one.