### PR TITLE
Underscores in numbers

### DIFF
--- a/src/main/java/helper/Types.java
+++ b/src/main/java/helper/Types.java
@@ -82,19 +82,17 @@ public class Types implements Comparable<Types> {
 	}
 
 	/**
-	 * Gets the larger type (the one with the most range of values)
+	 * Gets the larger type (the one with the most range of values) that is a result of the operation.
 	 * Ex: float & long = float;
+	 * byte + char => int, and similar stuff
 	 * @param other The Register constant type of the second item.
 	 * @return The Register constant type of the result.
 	 */
-	public Types getLarger(@NotNull Types other) {
-		if (this.equals(other)) return this;
+	public Types getResult(@NotNull Types other) {
 		if (this.equals(DOUBLE) || other.equals(DOUBLE)) return DOUBLE;
 		if (this.equals(FLOAT) || other.equals(FLOAT)) return FLOAT;
 		if (this.equals(LONG) || other.equals(LONG)) return LONG;
-		if (this.equals(INT) || other.equals(INT)) return INT;
-		if (this.equals(SHORT) || other.equals(SHORT)) return SHORT;
-		return BYTE;
+		return INT;
 	}
 
 	/** Removes an array dimension, returning the new type. If it can't be removed, throws a CompileException */
@@ -256,11 +254,6 @@ public class Types implements Comparable<Types> {
 
 		// not a primitive or boolean -- can't be converted from other primitives
 		return -1;
-	}
-
-	/** Returns if this type is a floating point one (float or double) */
-	public boolean isFloatingPoint() {
-		return this.equals(FLOAT) || this.equals(DOUBLE);
 	}
 
 	/** Returns the number of bytes required to represent this register. 1, 2, 4, or 8. */

--- a/src/main/java/intermediate/BinaryOpStatement.java
+++ b/src/main/java/intermediate/BinaryOpStatement.java
@@ -70,7 +70,7 @@ public class BinaryOpStatement implements InterStatement {
 				throw new CompileException("Can't perform operator: " + type.getRepresentation() + " on boolean.",
 					fileName, line);
 			}
-			Types larger = src1.getType().getLarger(src2.getType());
+			Types larger = src1.getType().getResult(src2.getType());
 
 			// add the conversions necessary
 			src1Converted = func.allocator.getNext(larger);
@@ -92,7 +92,7 @@ public class BinaryOpStatement implements InterStatement {
 		//  op src2, temp ---- this means temp = temp op src2
 		//  mov temp, dest
 
-		X64PseudoRegister temp = context.getNextQuadRegister();
+		X64PseudoRegister temp = context.getNextRegister(src1Converted.getType());
 
 		// convert src1 to src1Converted
 		for (InterStatement s : conversionSrc1) {

--- a/src/main/java/intermediate/LoadLiteralStatement.java
+++ b/src/main/java/intermediate/LoadLiteralStatement.java
@@ -139,7 +139,7 @@ public class LoadLiteralStatement implements InterStatement, NewStringUTF_JNI {
 					r.toX64()
 				)
 			);
-		} else if (r.getType().getIntermediateRepresentation().equals(Types.STRING.getIntermediateRepresentation())) {
+		} else if (r.getType().equals(Types.STRING)) {
 			// trim off the " and the beginning and the end, insert into data segment
 			String label = context.insertDataString(value.substring(1, value.length() - 1));
 

--- a/src/main/java/intermediate/StoreAddressStatement.java
+++ b/src/main/java/intermediate/StoreAddressStatement.java
@@ -173,7 +173,7 @@ public class StoreAddressStatement implements InterStatement,
 				// buffer = Get<PrimitiveType>ArrayElements(JNIEnv *env, array, jboolean* isCopy)
 				//   isCopy can be used to determine if it's able to make a copy, or actually memory map it
 				//   can just pass null in instead, as we're going to do the release anyways
-				X64PseudoRegister buffer = addGetPrimitiveArrayElements(context, array, intermediate.getType());
+				X64PseudoRegister buffer = addGetPrimitiveArrayElements(context, array, destinationType);
 
 				//  set the memory at the buffer+index*scaling
 				// mov %source, (%baseReg, %indexReg, scale factor)

--- a/src/main/java/main/JavaParser.jj
+++ b/src/main/java/main/JavaParser.jj
@@ -104,8 +104,81 @@ TOKEN : /* RESERVED WORDS AND LITERALS */
 | < WHILE: "while" >
 }
 
-TOKEN : /* LITERALS that are regular expressions, numbers aren't easily represented as such */
+TOKEN : /* LITERALS */
 {
+  < INTEGER_LITERAL:
+        <DECIMAL_LITERAL> (["l","L"])?
+      | <HEX_LITERAL> (["l","L"])?
+      | <OCTAL_LITERAL> (["l","L"])?
+      | <BINARY_LITERAL> (["l","L"])?
+  >
+|
+// base 10
+  < #DECIMAL_LITERAL:
+    "0"
+  | ["1"-"9"] (<DIGITS>)?
+  | ["1"-"9"] <UNDERSCORES> <DIGITS>
+  >
+|
+  < #UNDERSCORES: ("_")+ >
+|
+  < #DIGITS: <DIGIT> ((<DIGITS_AND_UNDERSCORES>)? <DIGIT>)? >
+|
+  < #DIGITS_AND_UNDERSCORES: (<DIGIT_OR_UNDERSCORE>)+ >
+|
+  < #DIGIT_OR_UNDERSCORE: <DIGIT> | "_" >
+|
+  < #DIGIT: ["0"-"9"]>
+|
+
+// base 16
+  < #HEX_LITERAL: "0" ["x","X"] <HEX_DIGITS> >
+|
+  < #HEX_DIGITS: <HEX_DIGIT> ((<HEX_DIGITS_AND_UNDERSCORES>)? <HEX_DIGIT>)?>
+|
+  < #HEX_DIGITS_AND_UNDERSCORES: (<HEX_DIGIT_OR_UNDERSCORE>)+ >
+|
+  < #HEX_DIGIT_OR_UNDERSCORE: <HEX_DIGIT> | "_" >
+|
+  < #HEX_DIGIT: ["0"-"9", "A"-"F", "a"-"f"] >
+|
+
+// base 8
+  < #OCTAL_LITERAL: "0" (<UNDERSCORES>)? <OCTAL_DIGITS> > // intentional, Java Language Spec is different here
+|
+  < #OCTAL_DIGITS: <OCTAL_DIGIT> ((<OCTAL_DIGITS_AND_UNDERSCORES>)? <OCTAL_DIGIT>)? >
+|
+  < #OCTAL_DIGITS_AND_UNDERSCORES: (<OCTAL_DIGIT_OR_UNDERSCORE>)+ >
+|
+  < #OCTAL_DIGIT_OR_UNDERSCORE: <OCTAL_DIGIT> | "_" >
+|
+  < #OCTAL_DIGIT: ["0"-"7"] >
+|
+
+// base 2
+  < #BINARY_LITERAL: "0" ["b", "B"] <BINARY_DIGITS> >
+|
+  < #BINARY_DIGITS: <BINARY_DIGIT> ((<BINARY_DIGITS_AND_UNDERSCORES>)? <BINARY_DIGIT>)? >
+|
+  < #BINARY_DIGITS_AND_UNDERSCORES: (<BINARY_DIGIT_OR_UNDERSCORE>)+ >
+|
+  < #BINARY_DIGIT_OR_UNDERSCORE: <BINARY_DIGIT> | "_" >
+|
+  < #BINARY_DIGIT: "0" | "1" >
+|
+
+// floats and doubles
+  < FLOATING_POINT_LITERAL:
+        (["0"-"9"])+ "." (["0"-"9"])* (<EXPONENT>)? (["f","F","d","D"])?
+      | "." (["0"-"9"])+ (<EXPONENT>)? (["f","F","d","D"])?
+      | (["0"-"9"])+ <EXPONENT> (["f","F","d","D"])?
+      | (["0"-"9"])+ (<EXPONENT>)? ["f","F","d","D"]
+  >
+|
+  < #EXPONENT: ["e","E"] (["+","-"])? (["0"-"9"])+ >
+|
+  < #NON_ZERO_DIGIT: ["1"-"9"] >
+|
   < CHARACTER_LITERAL:
       "'"
       (   (~["'","\\","\n","\r"])
@@ -131,6 +204,12 @@ TOKEN : /* LITERALS that are regular expressions, numbers aren't easily represen
       )*
       "\""
   >
+}
+
+TOKEN : /* IDENTIFIERS */
+{
+    < IDENTIFIER: <LETTER> (<LETTER>|<DIGIT>)* >
+|   < #LETTER: [ "A"-"Z", "a"-"z", "_" ] >
 }
 
 TOKEN : /* SEPARATORS */
@@ -190,40 +269,6 @@ TOKEN : /* OPERATORS */
 
 
 /*************  ACTUAL GRAMMAR NOW *******/
-
-// identifiers
-String Identifier():
-{
-    StringBuilder value = new StringBuilder();
-    char t;
-    long n;
-}
-{
-    t=Letter() { value.append(t); }
-    (
-        t=Letter() { value.append(t); }
-    |
-        n=Digit() { value.append("" + n); }
-    )*
-    {
-        return value.toString();
-    }
-}
-
-// This would be a part of a regex token, but then there's problems with conflicts with the x, and a-f in
-//  the literals for numbers
-char Letter():
-{}
-{
-    ("A" | "B" | "C" | "D" | "E" | "F" | "G" | "H" | "I" | "J" | "K" | "L" | "M"
-  | "N" | "O" | "P" | "Q" | "R" | "S" | "T" | "U" | "V" | "W" | "X" | "Y" | "Z"
-  | "A" | "B" | "C" | "D" | "E" | "F" | "G" | "H" | "I" | "J" | "K" | "L" | "M"
-  | "N" | "O" | "P" | "Q" | "R" | "S" | "T" | "U" | "V" | "W" | "X" | "Y" | "Z")
-  {
-    return token.image.charAt(0);
-  }
-}
-
 // the whole file is a compilation unit
 CompilationUnit CompilationUnit(String filename) :
 {
@@ -295,7 +340,7 @@ TypeDecNode TypeDeclaration() :
 
 ClassNode ClassDeclaration() :
 {
-    String name;
+    Token t;
     ClassBodyNode b;
 
     ArrayList<ClassBodyNode> body = new ArrayList<ClassBodyNode>();
@@ -310,12 +355,12 @@ ClassNode ClassDeclaration() :
     ( <ABSTRACT> { isAbstract=true; }
         | <FINAL> { isFinal=true; }
         | <PUBLIC> { isPublic=true; } )*
-    <CLASS> name=Identifier() [ typeParams=ClassTypeParameters() ]
+    <CLASS> t=<IDENTIFIER> [ typeParams=ClassTypeParameters() ]
     [ <EXTENDS> superClass=Name() ]
     [ <IMPLEMENTS> interfaces=NameList() ]
     <LBRACE> ( b=ClassBodyDeclaration() { body.add(b); } )* <RBRACE>
     {
-        return new ClassNode(fileName, token.beginLine, isAbstract, isFinal, isPublic, name, typeParams,
+        return new ClassNode(fileName, token.beginLine, isAbstract, isFinal, isPublic, t.image, typeParams,
             superClass, interfaces, body);
     }
 }
@@ -367,13 +412,14 @@ void MethodDeclarationLookahead() :
 {}
 {
   ( "public" | "protected" | "private" | "static" | "abstract" | "final" | "native" | "synchronized" )*
-  ResultType() Identifier() "("
+  ResultType() <IDENTIFIER> "("
 }
 
 InterfaceNode InterfaceDeclaration() :
 {
     // temporaries
     ClassBodyNode b;
+    Token t;
 
     // fields of created object
     ArrayList<NameNode> extendsList = null;
@@ -382,7 +428,7 @@ InterfaceNode InterfaceDeclaration() :
 }
 {
     ( <ABSTRACT> | <PUBLIC> )* // all interfaces are public and abstract by default.
-    <INTERFACE> name=Identifier()
+    <INTERFACE> t=<IDENTIFIER> { name = t.image; }
     [ <EXTENDS> extendsList=NameList() ]
     "{" ( b=InterfaceMemberDeclaration() { body.add(b); } )* "}"
     {
@@ -412,9 +458,10 @@ EnumNode EnumDeclaration() :
 {
     ArrayList<String> body;
     String name;
+    Token t;
 }
 {
-    (<PUBLIC>)* <ENUM> name=Identifier()
+    (<PUBLIC>)* <ENUM> t=<IDENTIFIER> {name = t.image; }
     <LBRACE> body=EnumBody() <RBRACE>
     {
         return new EnumNode(fileName, token.beginLine, name, body);
@@ -424,11 +471,11 @@ EnumNode EnumDeclaration() :
 ArrayList<String> EnumBody() :
 {
     ArrayList<String> a = new ArrayList<String>();
-    String t;
+    Token t;
 }
 { // the constants that could be the values of the ENUM
-    t=Identifier() { a.add(t); }
-    ("," t=Identifier() { a.add(t); })*
+    t=<IDENTIFIER> { a.add(t.image); }
+    ("," t=<IDENTIFIER> { a.add(t.image); })*
     {
         return a;
     }
@@ -465,10 +512,10 @@ VariableDecNode VariableDeclarator() :
 VariableIdNode VariableDeclaratorId() :
 {
     VariableIdNode v = new VariableIdNode(fileName, token.beginLine);
-    String t;
+    Token t;
 }
 {
-    t=Identifier(){ v.name=t; }
+    t=<IDENTIFIER>{ v.name=t.image; }
     ( <LBRACKET> <RBRACKET> {v.numDimensions++; } )*
     {
         return v;
@@ -503,6 +550,7 @@ MethodNode MethodDeclaration() :
     ArrayList<NameNode> throwsList = null;
     BlockNode code = null;
 
+    Token t;
 }
 {
     ( <PUBLIC> { isPublic=true;} | <PROTECTED> { isProtected=true; }
@@ -510,7 +558,7 @@ MethodNode MethodDeclaration() :
     | <ABSTRACT> { isAbstract=true; } | <FINAL> { isFinal=true; }
     | <NATIVE> { isNative=true; } | <SYNCHRONIZED> { isSynchronized=true; } )*
     returnType=ResultType()
-    name=Identifier()
+    t=<IDENTIFIER> { name = t.image; }
     params=FormalParameters()
     // array parts after the parameters
     ( <LBRACKET> <RBRACKET> { returnType = Types.arrayOf(returnType); } )*
@@ -551,14 +599,14 @@ ParamNode FormalParameter() :
 ConstructorNode ConstructorDeclaration() :
 {
     ConstructorNode c = new ConstructorNode(fileName, token.beginLine);
-    String t;
+    Token t;
     BlockStatementNode b;
 }
 {
     [ <PUBLIC> { c.isPublic = true; }
     | <PROTECTED> {c.isProtected = true;}
     | <PRIVATE> {c.isPrivate = true; } ]
-    t=Identifier() { c.name = t; }
+    t=<IDENTIFIER> { c.name = t.image; }
     c.params=FormalParameters()
     [ <THROWS> c.throwsList=NameList() ]
     <LBRACE> [ LOOKAHEAD(2) ExplicitConstructorInvocation() ]
@@ -630,6 +678,7 @@ NameNode Name() :
  * Also support generics, making this require even more lookahead
  */
 {
+    Token t;
     String name;
     ArrayList<GenericNode> generics = null;
 }
@@ -637,8 +686,8 @@ NameNode Name() :
     // need to make this so that NameNode isn't recursively defined, so that
     //  we can make another method for the bounds, since you can have a list
     //  of them using super and extends, list is separated with '&'
-    name=Identifier()
-    ( LOOKAHEAD(2) "." t=Identifier() {
+    t=<IDENTIFIER> { name = t.image; }
+    ( LOOKAHEAD(2) "." t=<IDENTIFIER> {
         name += "." + t.image;
     } )*
     ( LOOKAHEAD(<LT> GenericList() <GT>) <LT> generics=GenericList() <GT>)?
@@ -1081,7 +1130,7 @@ void CastLookahead() :
   LOOKAHEAD("(" Name() "[")
   "(" Name() "[" "]"
 |
-  "(" Name() ")" ( "~" | "!" | "(" | Identifier() | "this" | "super" | "new" | Literal() )
+  "(" Name() ")" ( "~" | "!" | "(" | <IDENTIFIER> | "this" | "super" | "new" | Literal() )
 }
 
 Expression PostfixExpression() :
@@ -1137,7 +1186,7 @@ Expression PrimaryExpression() :
     Expression temp;
     NameNode tempName;
     ArrayList<Expression> tempList;
-    String t;
+    Token t;
 
 
     // if the primary expression part is just 'this', which is just a qualifier for the
@@ -1163,11 +1212,15 @@ Expression PrimaryExpression() :
     (
         builtUp = Literal()
     |
-        identifier=Identifier()  // keep it for this iteration, use in the next one.
+        t=<IDENTIFIER>
+        {
+            // keep it for this iteration, use in the next one.
+            identifier = t.image;
+        }
     |
         "this" { primaryThis = true; }
     |
-        "super" "." superIdentifier=Identifier()
+        "super" "." t=<IDENTIFIER> { superIdentifier = t.image; }
     |
         // parentheses are for specifying tree order, so don't need them in the result
         //  also we can't have anything after these expressions be part of the primary expression.
@@ -1191,7 +1244,7 @@ Expression PrimaryExpression() :
                         builtUp = new SuperFieldExpressionNode(superIdentifier, fileName, token.beginLine);
                     }
                 }
-                
+
                 if (builtUp == null) {
                     // identifier is not null, build up from that
                     builtUp = new UnknownIdentifierNode(identifier, fileName, token.beginLine);
@@ -1207,7 +1260,7 @@ Expression PrimaryExpression() :
                 builtUp = new ArrayIndexExpressionNode(builtUp, temp, fileName, token.beginLine);
             }
         |
-            "." t=Identifier()
+            "." t=<IDENTIFIER>
             {
                 if (builtUp == null) {
                     if (primaryThis) {
@@ -1220,14 +1273,14 @@ Expression PrimaryExpression() :
                         // don't know what the specific type is
                         builtUp = new UnknownIdentifierNode(identifier, fileName, token.beginLine);
                     }
-                    identifier = t;
+                    identifier = t.image;
                 } else if (identifier != null){
                     // builtUp is already something, set the field name
                     builtUp = new FieldExpressionNode(builtUp, identifier, fileName, token.beginLine);
-                    identifier = t;
+                    identifier = t.image;
                 } else {
                     // identifier == null, there's not anything extra we need to build up
-                    identifier = t;
+                    identifier = t.image;
                 }
 
             }
@@ -1262,12 +1315,11 @@ Expression PrimaryExpression() :
 LiteralExpressionNode Literal() :
 {
     Token t;
-    LiteralExpressionNode n;
 }
 {
-    (n=NumericalLiteral() { return n; })
-|
-    (t=<CHARACTER_LITERAL>
+    (t=<INTEGER_LITERAL>
+|   t=<FLOATING_POINT_LITERAL>
+|   t=<CHARACTER_LITERAL>
 |   t=<STRING_LITERAL>
 |   t=<TRUE>
 |   t=<FALSE>
@@ -1276,379 +1328,6 @@ LiteralExpressionNode Literal() :
         return new LiteralExpressionNode(fileName, token.beginLine, t.image);
     }
 }
-
-/* These numerical literals are implemented in order of how they are in the Java Language Specification */
-
-LiteralExpressionNode NumericalLiteral():
-{ NumericalLiteralNode n; }
-{
-    n=IntegerLiteral() { return n; }
-/*|
-    n=FloatingPointLiteral() { return n; }
-    When floating point literals are implemented,
-    https://docs.oracle.com/javase/specs/jls/se11/html/jls-3.html#jls-FloatingPointLiteral
-    */
-}
-
-IntegerLiteralNode IntegerLiteral(): // either int or long
-{
-    long value;
-}
-{
-    (
-        value = DecimalLiteral()
-    |   value = HexIntegerLiteral()
-    |   value = OctalIntegerLiteral()
-    |   value = BinaryIntegerLiteral()
-    )
-    ( "l" { return new LongLiteralNode(value); })?
-    ( "L" { return new LongLiteralNode(value); })?
-    { return new IntegerLiteralNode(value); }
-}
-
-long DecimalLiteral():
-{
-    long value = 0;
-    long temp;
-    String temp2;
-}
-{
-    "0" { return 0; }
-|   temp = NonZeroDigit() { value *= 10;  value += temp; }
-    ( temp=Digits() { temp2 = "" + value + temp; value = Long.parseLong(temp2); })?
-    {
-        return value;
-    }
-|
-    temp = NonZeroDigit() { value *= 10; value += temp; }
-    Underscores()
-    temp = Digits() { temp2 = "" + value + temp; value = Long.parseLong(temp2); }
-    {
-        return value;
-    }
-}
-
-long NonZeroDigit():{}
-{
-    "1" { return 1; }
-|   "2" { return 2; }
-|   "3" { return 3; }
-|   "4" { return 4; }
-|   "5" { return 5; }
-|   "6" { return 6; }
-|   "7" { return 7; }
-|   "8" { return 8; }
-|   "9" { return 9; }
-}
-
-// returns the numerical value of the digits
-long Digits():
-{
-    long result;
-    long temp;
-    Long temp2;
-    String concat;
-}
-{
-    result=Digit()
-    (
-        (temp2=DigitsAndUnderscores() {
-            // concatenate result if not null
-            if (temp2 != null) {
-                concat = "" + result + temp2;
-                result = Long.parseLong(concat);
-            }
-        })?
-        temp=Digit() { /* concatenate result */ result *= 10; result += temp; }
-    )?
-}
-
-long Digit():
-{
-    long temp;
-}
-{
-    "0" { return 0; }
-|   temp=NonZeroDigit() { return temp; }
-}
-
-// returns the value, or null if it's just a bunch of underscores
-Long DigitsAndUnderscores():
-{
-    Long result = null;
-    Long temp;
-    String concat;
-}
-{
-    (
-        temp=DigitOrUnderscore()
-        {
-            if (result == null) {
-                result = temp;
-            } else if (temp != null) {
-                // concatenate
-                concat = "" + result + temp;
-                result = Long.parseLong(concat);
-            }
-            // no change otherwise
-        }
-    )+
-    {
-        return result;
-    }
-}
-
-// will return null if it's an underscore
-Long DigitOrUnderscore():
-{
-    long temp;
-}
-{
-    temp=Digit() { return temp; }
-|
-    "_" { return null; }
-}
-
-// consumes underscore tokens
-void Underscores():{}
-{
-    "_" ("_")*
-}
-
-long HexIntegerLiteral():
-{
-    long value;
-}
-{
-    "0" ["X" "x"] value = HexDigits() { return value; }
-}
-
-// similar to DecimalDigits, but multiply by 16
-long HexDigits():
-{
-    long result;
-    long temp;
-    Long temp2;
-    String concat;
-}
-{
-    result=HexDigit()
-    (
-        (temp2=HexDigitsAndUnderscores() {
-            // concatenate result if not null
-            if (temp2 != null) {
-                concat = "" + result + temp2;
-                result = Long.parseLong(concat, 16);
-            }
-        })?
-        temp=HexDigit() { /* concatenate result */ result *= 16; result += temp; }
-    )?
-}
-
-// comsumes a hex digit and returns its value.
-long HexDigit():
-{
-    long value;
-}
-{
-    value=Digit() { return value; }
-|   ("a" | "A") { return 10; }
-|   ("b" | "B") { return 11; }
-|   ("c" | "C") { return 12; }
-|   ("d" | "D") { return 13; }
-|   ("e" | "E") { return 14; }
-|   ("f" | "F") { return 15; }
-}
-
-Long HexDigitsAndUnderscores():
-{
-    Long result = null;
-    Long temp;
-    String concat;
-}
-{
-    (
-        temp=HexDigitOrUnderscore()
-        {
-            if (result == null) {
-                result = temp;
-            } else if (temp != null) {
-                // concatenate
-                concat = "" + result + temp;
-                result = Long.parseLong(concat, 16);
-            }
-            // no change otherwise
-        }
-    )+
-    {
-        return result;
-    }
-}
-
-Long HexDigitOrUnderscore():
-{
-    long value;
-}
-{
-    value=HexDigit() { return value; }
-|
-    "_" { return null; }
-}
-
-// similar pattern as the hex ones
-long OctalIntegerLiteral():
-{
-    long value;
-}
-{
-    "0" (Underscores())? value=OctalDigits() { return value; }
-}
-
-long OctalDigits():
-{
-    long result;
-    long temp;
-    Long temp2;
-    String concat;
-}
-{
-    result=OctalDigit()
-    (
-        (temp2=OctalDigitsAndUnderscores() {
-            // concatenate result if not null
-            if (temp2 != null) {
-                concat = "" + result + temp2;
-                result = Long.parseLong(concat, 8);
-            }
-        })?
-        temp=HexDigit() { /* concatenate result */ result *= 8; result += temp; }
-    )?
-}
-
-// comsumes a octal digit and returns its value.
-long OctalDigit():{}
-{
-    "0" { return 0; }
-|   "1" { return 1; }
-|   "2" { return 2; }
-|   "3" { return 3; }
-|   "4" { return 4; }
-|   "5" { return 5; }
-|   "6" { return 6; }
-|   "7" { return 7; }
-|   "8" { return 8; }
-|   "9" { return 9; }
-}
-
-Long OctalDigitsAndUnderscores():
-{
-    Long result = null;
-    Long temp;
-    String concat;
-}
-{
-    (
-        temp=OctalDigitOrUnderscore()
-        {
-            if (result == null) {
-                result = temp;
-            } else if (temp != null) {
-                // concatenate
-                concat = "" + result + temp;
-                result = Long.parseLong(concat, 8);
-            }
-            // no change otherwise
-        }
-    )+
-    {
-        return result;
-    }
-}
-
-
-Long OctalDigitOrUnderscore():
-{
-    long value;
-}
-{
-    value=OctalDigit() { return value; }
-|
-    "_" { return null; }
-}
-
-// also similar pattern
-long BinaryIntegerLiteral():
-{
-    long value;
-}
-{
-    "0" ["b" "B"] (Underscores())? value=BinaryDigits() { return value; }
-}
-
-long BinaryDigits():
-{
-    long result;
-    long temp;
-    Long temp2;
-    String concat;
-}
-{
-    result=BinaryDigit()
-    (
-        (temp2=BinaryDigitsAndUnderscores() {
-            // concatenate result if not null
-            if (temp2 != null) {
-                concat = "" + result + temp2;
-                result = Long.parseLong(concat, 2);
-            }
-        })?
-        temp=BinaryDigit() { /* concatenate result */ result *= 8; result += temp; }
-    )?
-}
-
-// comsumes a binary digit and returns its value.
-long BinaryDigit():{}
-{
-    "0" { return 0; }
-|   "1" { return 1; }
-}
-
-Long BinaryDigitsAndUnderscores():
-{
-    Long result = null;
-    Long temp;
-    String concat;
-}
-{
-    (
-        temp=BinaryDigitOrUnderscore()
-        {
-            if (result == null) {
-                result = temp;
-            } else if (temp != null) {
-                // concatenate
-                concat = "" + result + temp;
-                result = Long.parseLong(concat, 2);
-            }
-            // no change otherwise
-        }
-    )+
-    {
-        return result;
-    }
-}
-
-
-Long BinaryDigitOrUnderscore():
-{
-    long value;
-}
-{
-    value=BinaryDigit() { return value; }
-|
-    "_" { return null; }
-}
-
 
 ArrayList<Expression> Arguments() :
 {
@@ -1815,12 +1494,12 @@ StatementNode Statement() :
 LabeledStatementNode LabeledStatement() :
 {
     StatementNode statement;
-    String t;
+    Token t;
 }
 {
-    t=Identifier() ":" statement=Statement()
+    t=<IDENTIFIER> ":" statement=Statement()
     {
-        return new LabeledStatementNode(fileName, token.beginLine, t, statement);
+        return new LabeledStatementNode(fileName, token.beginLine, t.image, statement);
     }
 }
 
@@ -1843,7 +1522,7 @@ BlockStatementNode BlockStatement() :
     BlockStatementNode b;
 }
 {
-    LOOKAHEAD(Type() Identifier())
+    LOOKAHEAD(Type() <IDENTIFIER>)
     b=LocalVariableDeclaration() <SEMICOLON>
     {
         return b;
@@ -2008,7 +1687,7 @@ ForInitNode ForInit() :
     ForInitNode temp;
 }
 {
-    LOOKAHEAD( Type() Identifier() )
+    LOOKAHEAD( Type() <IDENTIFIER> )
     temp=LocalVariableDeclaration()
     {
         return temp;
@@ -2047,10 +1726,11 @@ StatementExprNodeList ForUpdate() :
 
 BreakStatementNode BreakStatement() :
 {
+    Token t;
     String image = null;
 }
 {
-    <BREAK> [ image=Identifier() ] <SEMICOLON>
+    <BREAK> [ t=<IDENTIFIER> { image = t.image; }] <SEMICOLON>
     {
         return new BreakStatementNode(fileName, token.beginLine, image);
     }
@@ -2058,10 +1738,11 @@ BreakStatementNode BreakStatement() :
 
 ContinueStatementNode ContinueStatement() :
 {
+    Token t;
     String image = null;
 }
 {
-    <CONTINUE> [ image=Identifier() ] <SEMICOLON>
+    <CONTINUE> [ t=<IDENTIFIER> { image = t.image; } ] <SEMICOLON>
     {
         return new ContinueStatementNode(fileName, token.beginLine, image);
     }

--- a/src/main/java/main/JavaParser.jj
+++ b/src/main/java/main/JavaParser.jj
@@ -1492,14 +1492,91 @@ Long HexDigitOrUnderscore():
     "_" { return null; }
 }
 
-long OctalIntegerLiteral():{}{}
-long BinaryIntegerLiteral():{}{}
+// similar pattern as the hex ones
+long OctalIntegerLiteral():
+{
+    long value;
+}
+{
+    "0" (Underscores())? value=OctalDigits() { return value; }
+}
 
-FloatingPointLiteral FloatingPointLiteral(): // either float or double
+long OctalDigits():
 {
+    long result;
+    long temp;
+    Long temp2;
+    String concat;
 }
 {
+    result=OctalDigit()
+    (
+        (temp2=OctalDigitsAndUnderscores() {
+            // concatenate result if not null
+            if (temp2 != null) {
+                concat = "" + result + temp2;
+                result = Long.parseLong(concat, 8);
+            }
+        })?
+        temp=HexDigit() { /* concatenate result */ result *= 8; result += temp; }
+    )?
 }
+
+// comsumes a octal digit and returns its value.
+long OctalDigit():{}
+{
+    "0" { return 0; }
+|   "1" { return 1; }
+|   "2" { return 2; }
+|   "3" { return 3; }
+|   "4" { return 4; }
+|   "5" { return 5; }
+|   "6" { return 6; }
+|   "7" { return 7; }
+|   "8" { return 8; }
+|   "9" { return 9; }
+}
+
+Long OctalDigitsAndUnderscores():
+{
+    Long result = null;
+    Long temp;
+    String concat;
+}
+{
+    (
+        temp=OctalDigitOrUnderscore()
+        {
+            if (result == null) {
+                result = temp;
+            } else if (temp != null) {
+                // concatenate
+                concat = "" + result + temp;
+                result = Long.parseLong(concat, 8);
+            }
+            // no change otherwise
+        }
+    )+
+    {
+        return result;
+    }
+}
+
+
+Long OctalDigitOrUnderscore():
+{
+    long value;
+}
+{
+    value=OctalDigit() { return value; }
+|
+    "_" { return null; }
+}
+
+
+// long BinaryIntegerLiteral():{}{}
+
+// FloatingPointLiteral FloatingPointLiteral():{}{} // either float or double
 
 // FloatingPointLiteral FloatingPointLiteral(): {} {}
 //

--- a/src/main/java/main/JavaParser.jj
+++ b/src/main/java/main/JavaParser.jj
@@ -133,12 +133,6 @@ TOKEN : /* LITERALS that are regular expressions, numbers aren't easily represen
   >
 }
 
-TOKEN : /* IDENTIFIERS */
-{
-    < LETTER: [ "A"-"Z", "a"-"z", "_" ] >
-|   < DIGIT: [ "0"-"9" ] >
-}
-
 TOKEN : /* SEPARATORS */
 {
   < LPAREN: "(" >
@@ -201,18 +195,33 @@ TOKEN : /* OPERATORS */
 String Identifier():
 {
     StringBuilder value = new StringBuilder();
-    Token t;
+    char t;
+    long n;
 }
 {
-    t=<LETTER> { value.append(t.image); }
+    t=Letter() { value.append(t); }
     (
-        t=<LETTER> { value.append(t.image); }
+        t=Letter() { value.append(t); }
     |
-        t=<DIGIT> { value.append(t.image); }
+        n=Digit() { value.append("" + n); }
     )*
     {
         return value.toString();
     }
+}
+
+// This would be a part of a regex token, but then there's problems with conflicts with the x, and a-f in
+//  the literals for numbers
+char Letter():
+{}
+{
+    ("A" | "B" | "C" | "D" | "E" | "F" | "G" | "H" | "I" | "J" | "K" | "L" | "M"
+  | "N" | "O" | "P" | "Q" | "R" | "S" | "T" | "U" | "V" | "W" | "X" | "Y" | "Z"
+  | "A" | "B" | "C" | "D" | "E" | "F" | "G" | "H" | "I" | "J" | "K" | "L" | "M"
+  | "N" | "O" | "P" | "Q" | "R" | "S" | "T" | "U" | "V" | "W" | "X" | "Y" | "Z")
+  {
+    return token.image.charAt(0);
+  }
 }
 
 // the whole file is a compilation unit

--- a/src/main/java/main/JavaParser.jj
+++ b/src/main/java/main/JavaParser.jj
@@ -104,29 +104,8 @@ TOKEN : /* RESERVED WORDS AND LITERALS */
 | < WHILE: "while" >
 }
 
-TOKEN : /* LITERALS */
+TOKEN : /* LITERALS that are regular expressions, numbers aren't easily represented as such */
 {
-  < INTEGER_LITERAL:
-        <DECIMAL_LITERAL> (["l","L"])?
-      | <HEX_LITERAL> (["l","L"])?
-      | <OCTAL_LITERAL> (["l","L"])?
-  >
-|
-  < #DECIMAL_LITERAL: ["1"-"9"] (["0"-"9"])* >
-|
-  < #HEX_LITERAL: "0" ["x","X"] (["0"-"9","a"-"f","A"-"F"])+ >
-|
-  < #OCTAL_LITERAL: "0" (["0"-"7"])* >
-|
-  < FLOATING_POINT_LITERAL:
-        (["0"-"9"])+ "." (["0"-"9"])* (<EXPONENT>)? (["f","F","d","D"])?
-      | "." (["0"-"9"])+ (<EXPONENT>)? (["f","F","d","D"])?
-      | (["0"-"9"])+ <EXPONENT> (["f","F","d","D"])?
-      | (["0"-"9"])+ (<EXPONENT>)? ["f","F","d","D"]
-  >
-|
-  < #EXPONENT: ["e","E"] (["+","-"])? (["0"-"9"])+ >
-|
   < CHARACTER_LITERAL:
       "'"
       (   (~["'","\\","\n","\r"])
@@ -156,9 +135,8 @@ TOKEN : /* LITERALS */
 
 TOKEN : /* IDENTIFIERS */
 {
-    < IDENTIFIER: <LETTER> (<LETTER>|<DIGIT>)* >
-|   < #LETTER: [ "A"-"Z", "a"-"z", "_" ] >
-|   < #DIGIT: [ "0"-"9" ] >
+    < LETTER: [ "A"-"Z", "a"-"z", "_" ] >
+|   < DIGIT: [ "0"-"9" ] >
 }
 
 TOKEN : /* SEPARATORS */
@@ -218,6 +196,25 @@ TOKEN : /* OPERATORS */
 
 
 /*************  ACTUAL GRAMMAR NOW *******/
+
+// identifiers
+String Identifier():
+{
+    StringBuilder value = new StringBuilder();
+    Token t;
+}
+{
+    t=<LETTER> { value.append(t.image); }
+    (
+        t=<LETTER> { value.append(t.image); }
+    |
+        t=<DIGIT> { value.append(t.image); }
+    )*
+    {
+        return value.toString();
+    }
+}
+
 // the whole file is a compilation unit
 CompilationUnit CompilationUnit(String filename) :
 {
@@ -289,7 +286,7 @@ TypeDecNode TypeDeclaration() :
 
 ClassNode ClassDeclaration() :
 {
-    Token t;
+    String name;
     ClassBodyNode b;
 
     ArrayList<ClassBodyNode> body = new ArrayList<ClassBodyNode>();
@@ -304,12 +301,12 @@ ClassNode ClassDeclaration() :
     ( <ABSTRACT> { isAbstract=true; }
         | <FINAL> { isFinal=true; }
         | <PUBLIC> { isPublic=true; } )*
-    <CLASS> t=<IDENTIFIER> [ typeParams=ClassTypeParameters() ]
+    <CLASS> name=Identifier() [ typeParams=ClassTypeParameters() ]
     [ <EXTENDS> superClass=Name() ]
     [ <IMPLEMENTS> interfaces=NameList() ]
     <LBRACE> ( b=ClassBodyDeclaration() { body.add(b); } )* <RBRACE>
     {
-        return new ClassNode(fileName, token.beginLine, isAbstract, isFinal, isPublic, t.image, typeParams,
+        return new ClassNode(fileName, token.beginLine, isAbstract, isFinal, isPublic, name, typeParams,
             superClass, interfaces, body);
     }
 }
@@ -361,14 +358,13 @@ void MethodDeclarationLookahead() :
 {}
 {
   ( "public" | "protected" | "private" | "static" | "abstract" | "final" | "native" | "synchronized" )*
-  ResultType() <IDENTIFIER> "("
+  ResultType() Identifier() "("
 }
 
 InterfaceNode InterfaceDeclaration() :
 {
     // temporaries
     ClassBodyNode b;
-    Token t;
 
     // fields of created object
     ArrayList<NameNode> extendsList = null;
@@ -377,7 +373,7 @@ InterfaceNode InterfaceDeclaration() :
 }
 {
     ( <ABSTRACT> | <PUBLIC> )* // all interfaces are public and abstract by default.
-    <INTERFACE> t=<IDENTIFIER> { name = t.image; }
+    <INTERFACE> name=Identifier()
     [ <EXTENDS> extendsList=NameList() ]
     "{" ( b=InterfaceMemberDeclaration() { body.add(b); } )* "}"
     {
@@ -407,10 +403,9 @@ EnumNode EnumDeclaration() :
 {
     ArrayList<String> body;
     String name;
-    Token t;
 }
 {
-    (<PUBLIC>)* <ENUM> t=<IDENTIFIER> {name = t.image; }
+    (<PUBLIC>)* <ENUM> name=Identifier()
     <LBRACE> body=EnumBody() <RBRACE>
     {
         return new EnumNode(fileName, token.beginLine, name, body);
@@ -420,11 +415,11 @@ EnumNode EnumDeclaration() :
 ArrayList<String> EnumBody() :
 {
     ArrayList<String> a = new ArrayList<String>();
-    Token t;
+    String t;
 }
 { // the constants that could be the values of the ENUM
-    t=<IDENTIFIER> { a.add(t.image); }
-    ("," t=<IDENTIFIER> { a.add(t.image); })*
+    t=Identifier() { a.add(t); }
+    ("," t=Identifier() { a.add(t); })*
     {
         return a;
     }
@@ -461,10 +456,10 @@ VariableDecNode VariableDeclarator() :
 VariableIdNode VariableDeclaratorId() :
 {
     VariableIdNode v = new VariableIdNode(fileName, token.beginLine);
-    Token t;
+    String t;
 }
 {
-    t=<IDENTIFIER>{ v.name=t.image; }
+    t=Identifier(){ v.name=t; }
     ( <LBRACKET> <RBRACKET> {v.numDimensions++; } )*
     {
         return v;
@@ -499,7 +494,6 @@ MethodNode MethodDeclaration() :
     ArrayList<NameNode> throwsList = null;
     BlockNode code = null;
 
-    Token t;
 }
 {
     ( <PUBLIC> { isPublic=true;} | <PROTECTED> { isProtected=true; }
@@ -507,7 +501,7 @@ MethodNode MethodDeclaration() :
     | <ABSTRACT> { isAbstract=true; } | <FINAL> { isFinal=true; }
     | <NATIVE> { isNative=true; } | <SYNCHRONIZED> { isSynchronized=true; } )*
     returnType=ResultType()
-    t=<IDENTIFIER> { name = t.image; }
+    name=Identifier()
     params=FormalParameters()
     // array parts after the parameters
     ( <LBRACKET> <RBRACKET> { returnType = Types.arrayOf(returnType); } )*
@@ -548,14 +542,14 @@ ParamNode FormalParameter() :
 ConstructorNode ConstructorDeclaration() :
 {
     ConstructorNode c = new ConstructorNode(fileName, token.beginLine);
-    Token t;
+    String t;
     BlockStatementNode b;
 }
 {
     [ <PUBLIC> { c.isPublic = true; }
     | <PROTECTED> {c.isProtected = true;}
     | <PRIVATE> {c.isPrivate = true; } ]
-    t=<IDENTIFIER> { c.name = t.image; }
+    t=Identifier() { c.name = t; }
     c.params=FormalParameters()
     [ <THROWS> c.throwsList=NameList() ]
     <LBRACE> [ LOOKAHEAD(2) ExplicitConstructorInvocation() ]
@@ -627,7 +621,6 @@ NameNode Name() :
  * Also support generics, making this require even more lookahead
  */
 {
-    Token t;
     String name;
     ArrayList<GenericNode> generics = null;
 }
@@ -635,8 +628,8 @@ NameNode Name() :
     // need to make this so that NameNode isn't recursively defined, so that
     //  we can make another method for the bounds, since you can have a list
     //  of them using super and extends, list is separated with '&'
-    t=<IDENTIFIER> { name = t.image; }
-    ( LOOKAHEAD(2) "." t=<IDENTIFIER> {
+    name=Identifier()
+    ( LOOKAHEAD(2) "." t=Identifier() {
         name += "." + t.image;
     } )*
     ( LOOKAHEAD(<LT> GenericList() <GT>) <LT> generics=GenericList() <GT>)?
@@ -1079,7 +1072,7 @@ void CastLookahead() :
   LOOKAHEAD("(" Name() "[")
   "(" Name() "[" "]"
 |
-  "(" Name() ")" ( "~" | "!" | "(" | <IDENTIFIER> | "this" | "super" | "new" | Literal() )
+  "(" Name() ")" ( "~" | "!" | "(" | Identifier() | "this" | "super" | "new" | Literal() )
 }
 
 Expression PostfixExpression() :
@@ -1135,7 +1128,7 @@ Expression PrimaryExpression() :
     Expression temp;
     NameNode tempName;
     ArrayList<Expression> tempList;
-    Token t;
+    String t;
 
 
     // if the primary expression part is just 'this', which is just a qualifier for the
@@ -1161,15 +1154,11 @@ Expression PrimaryExpression() :
     (
         builtUp = Literal()
     |
-        t=<IDENTIFIER>
-        {
-            // keep it for this iteration, use in the next one.
-            identifier = t.image;
-        }
+        identifier=Identifier()  // keep it for this iteration, use in the next one.
     |
         "this" { primaryThis = true; }
     |
-        "super" "." t=<IDENTIFIER> { superIdentifier = t.image; }
+        "super" "." superIdentifier=Identifier()
     |
         // parentheses are for specifying tree order, so don't need them in the result
         //  also we can't have anything after these expressions be part of the primary expression.
@@ -1209,7 +1198,7 @@ Expression PrimaryExpression() :
                 builtUp = new ArrayIndexExpressionNode(builtUp, temp, fileName, token.beginLine);
             }
         |
-            "." t=<IDENTIFIER>
+            "." t=Identifier()
             {
                 if (builtUp == null) {
                     if (primaryThis) {
@@ -1222,14 +1211,14 @@ Expression PrimaryExpression() :
                         // don't know what the specific type is
                         builtUp = new UnknownIdentifierNode(identifier, fileName, token.beginLine);
                     }
-                    identifier = t.image;
+                    identifier = t;
                 } else if (identifier != null){
                     // builtUp is already something, set the field name
                     builtUp = new FieldExpressionNode(builtUp, identifier, fileName, token.beginLine);
-                    identifier = t.image;
+                    identifier = t;
                 } else {
                     // identifier == null, there's not anything extra we need to build up
-                    identifier = t.image;
+                    identifier = t;
                 }
 
             }
@@ -1303,7 +1292,8 @@ IntegerLiteralNode IntegerLiteral(): // either int or long
     |   value = OctalIntegerLiteral()
     |   value = BinaryIntegerLiteral()
     )
-    ( ["l" "L"] { return new LongLiteralNode(value); })?
+    ( "l" { return new LongLiteralNode(value); })?
+    ( "L" { return new LongLiteralNode(value); })?
     { return new IntegerLiteralNode(value); }
 }
 
@@ -1453,12 +1443,12 @@ long HexDigit():
 }
 {
     value=Digit() { return value; }
-|   ["a" "A"] { return 10; }
-|   ["b" "B"] { return 11; }
-|   ["c" "C"] { return 12; }
-|   ["d" "D"] { return 13; }
-|   ["e" "E"] { return 14; }
-|   ["f" "F"] { return 15; }
+|   ("a" | "A") { return 10; }
+|   ("b" | "B") { return 11; }
+|   ("c" | "C") { return 12; }
+|   ("d" | "D") { return 13; }
+|   ("e" | "E") { return 14; }
+|   ("f" | "F") { return 15; }
 }
 
 Long HexDigitsAndUnderscores():
@@ -1816,12 +1806,12 @@ StatementNode Statement() :
 LabeledStatementNode LabeledStatement() :
 {
     StatementNode statement;
-    Token t;
+    String t;
 }
 {
-    t=<IDENTIFIER> ":" statement=Statement()
+    t=Identifier() ":" statement=Statement()
     {
-        return new LabeledStatementNode(fileName, token.beginLine, t.image, statement);
+        return new LabeledStatementNode(fileName, token.beginLine, t, statement);
     }
 }
 
@@ -1844,7 +1834,7 @@ BlockStatementNode BlockStatement() :
     BlockStatementNode b;
 }
 {
-    LOOKAHEAD(Type() <IDENTIFIER>)
+    LOOKAHEAD(Type() Identifier())
     b=LocalVariableDeclaration() <SEMICOLON>
     {
         return b;
@@ -2009,7 +1999,7 @@ ForInitNode ForInit() :
     ForInitNode temp;
 }
 {
-    LOOKAHEAD( Type() <IDENTIFIER> )
+    LOOKAHEAD( Type() Identifier() )
     temp=LocalVariableDeclaration()
     {
         return temp;
@@ -2048,11 +2038,10 @@ StatementExprNodeList ForUpdate() :
 
 BreakStatementNode BreakStatement() :
 {
-    Token t;
     String image = null;
 }
 {
-    <BREAK> [ t=<IDENTIFIER> { image = t.image; }] <SEMICOLON>
+    <BREAK> [ image=Identifier() ] <SEMICOLON>
     {
         return new BreakStatementNode(fileName, token.beginLine, image);
     }
@@ -2060,11 +2049,10 @@ BreakStatementNode BreakStatement() :
 
 ContinueStatementNode ContinueStatement() :
 {
-    Token t;
     String image = null;
 }
 {
-    <CONTINUE> [ t=<IDENTIFIER> { image = t.image; } ] <SEMICOLON>
+    <CONTINUE> [ image=Identifier() ] <SEMICOLON>
     {
         return new ContinueStatementNode(fileName, token.beginLine, image);
     }

--- a/src/main/java/main/JavaParser.jj
+++ b/src/main/java/main/JavaParser.jj
@@ -1278,6 +1278,182 @@ LiteralExpressionNode Literal() :
     }
 }
 
+/* These numerical literals are implemented in order of how they are in the Java Language Specification */
+
+LiteralExpressionNode NumericalLiteral():
+{ NumericalLiteralNode n; }
+{
+    n=IntegerLiteral() { return n; }
+|
+    n=FloatingPointLiteral() { return n; }
+}
+
+IntegerLiteralNode IntegerLiteral(): // either int or long
+{
+    long value;
+}
+{
+    value = DecimalLiteral()
+|   value = HexIntegerLiteral()
+|   value = OctalIntegerLiteral()
+|   value = BinaryIntegerLiteral()
+    { return new IntegerLiteralNode(value); }
+}
+
+long DecimalLiteral():
+{
+    long value = 0;
+    long temp;
+    String temp2;
+}
+{
+    "0" { return 0; }
+|   temp = NonZeroDigit() { value *= 10;  value += temp; }
+    ( temp=Digits() { temp2 = "" + value + temp; value = Long.parseLong(temp2); })?
+    {
+        return value;
+    }
+|
+    temp = NonZeroDigit() { value *= 10; value += temp; }
+    Underscores()
+    temp = Digits() { temp2 = "" + value + temp; value = Long.parseLong(temp2); }
+    {
+        return value;
+    }
+}
+
+long NonZeroDigit():{}
+{
+    "1" { return 1; }
+|   "2" { return 2; }
+|   "3" { return 3; }
+|   "4" { return 4; }
+|   "5" { return 5; }
+|   "6" { return 6; }
+|   "7" { return 7; }
+|   "8" { return 8; }
+|   "9" { return 9; }
+}
+
+// returns the numerical value of the digits
+long Digits():
+{
+    long result;
+    long temp;
+    Long temp2;
+    String concat;
+}
+{
+    result=Digit()
+    (
+        (temp2=DigitsAndUnderscores() {
+            // concatenate result if not null
+            if (temp2 != null) {
+                concat = "" + result + temp2;
+                result = Long.parseLong(concat);
+            }
+        })?
+        temp=Digit() { /* concatenate result */ result *= 10; result += temp; }
+    )?
+}
+
+long Digit():
+{
+    long temp;
+}
+{
+    "0" { return 0; }
+|   temp=NonZeroDigit() { return temp; }
+}
+
+// returns the value, or null if it's just a bunch of underscores
+Long DigitsAndUnderscores():
+{
+    Long result = null;
+    Long temp;
+    String concat;
+}
+{
+    (
+        temp=DigitOrUnderscore()
+        {
+            if (result == null) {
+                result = temp;
+            } else if (temp != null) {
+                // concatenate
+                concat = "" + result + temp;
+                result = Long.parseLong(concat);
+            }
+            // no change otherwise
+        }
+    )+
+    {
+        return result;
+    }
+}
+
+// will return null if it's an underscore
+Long DigitOrUnderscore():
+{
+    long temp;
+}
+{
+    temp=Digit() { return temp; }
+|
+    "_" { return null; }
+}
+
+// consumes underscore tokens
+void Underscores():{}
+{
+    "_" ("_")*
+}
+
+
+
+
+
+
+long HexIntegerLiteral(): {}{}
+long OctalIntegerLiteral():{}{}
+long BinaryIntegerLiteral():{}{}
+
+FloatingPointLiteral FloatingPointLiteral(): // either float or double
+{
+}
+{
+}
+
+// FloatingPointLiteral FloatingPointLiteral(): {} {}
+//
+
+/**
+  < INTEGER_LITERAL:
+        <DECIMAL_LITERAL> (["l","L"])?
+      | <HEX_LITERAL> (["l","L"])?
+      | <OCTAL_LITERAL> (["l","L"])?
+  >
+|
+  < #DECIMAL_LITERAL: ["1"-"9"] (["0"-"9"])* >
+|
+  < #HEX_LITERAL: "0" ["x","X"] (["0"-"9","a"-"f","A"-"F"])+ >
+|
+  < #OCTAL_LITERAL: "0" (["0"-"7"])* >
+|
+  < FLOATING_POINT_LITERAL:
+        (["0"-"9"])+ "." (["0"-"9"])* (<EXPONENT>)? (["f","F","d","D"])?
+      | "." (["0"-"9"])+ (<EXPONENT>)? (["f","F","d","D"])?
+      | (["0"-"9"])+ <EXPONENT> (["f","F","d","D"])?
+      | (["0"-"9"])+ (<EXPONENT>)? ["f","F","d","D"]
+  >
+|
+  < #EXPONENT: ["e","E"] (["+","-"])? (["0"-"9"])+ >
+
+*/
+
+
+
+
 ArrayList<Expression> Arguments() :
 {
     ArrayList<Expression> expressions = new ArrayList<Expression>();

--- a/src/main/java/main/JavaParser.jj
+++ b/src/main/java/main/JavaParser.jj
@@ -1293,10 +1293,13 @@ IntegerLiteralNode IntegerLiteral(): // either int or long
     long value;
 }
 {
-    value = DecimalLiteral()
-|   value = HexIntegerLiteral()
-|   value = OctalIntegerLiteral()
-|   value = BinaryIntegerLiteral()
+    (
+        value = DecimalLiteral()
+    |   value = HexIntegerLiteral()
+    |   value = OctalIntegerLiteral()
+    |   value = BinaryIntegerLiteral()
+    )
+    ( ["l" "L"] { return new LongLiteralNode(value); })?
     { return new IntegerLiteralNode(value); }
 }
 
@@ -1409,12 +1412,86 @@ void Underscores():{}
     "_" ("_")*
 }
 
+long HexIntegerLiteral():
+{
+    long value;
+}
+{
+    "0" ["X" "x"] value = HexDigits() { return value; }
+}
 
+// similar to DecimalDigits, but multiply by 16
+long HexDigits():
+{
+    long result;
+    long temp;
+    Long temp2;
+    String concat;
+}
+{
+    result=HexDigit()
+    (
+        (temp2=HexDigitsAndUnderscores() {
+            // concatenate result if not null
+            if (temp2 != null) {
+                concat = "" + result + temp2;
+                result = Long.parseLong(concat, 16);
+            }
+        })?
+        temp=HexDigit() { /* concatenate result */ result *= 16; result += temp; }
+    )?
+}
 
+// comsumes a hex digit and returns its value.
+long HexDigit():
+{
+    long value;
+}
+{
+    value=Digit() { return value; }
+|   ["a" "A"] { return 10; }
+|   ["b" "B"] { return 11; }
+|   ["c" "C"] { return 12; }
+|   ["d" "D"] { return 13; }
+|   ["e" "E"] { return 14; }
+|   ["f" "F"] { return 15; }
+}
 
+Long HexDigitsAndUnderscores():
+{
+    Long result = null;
+    Long temp;
+    String concat;
+}
+{
+    (
+        temp=HexDigitOrUnderscore()
+        {
+            if (result == null) {
+                result = temp;
+            } else if (temp != null) {
+                // concatenate
+                concat = "" + result + temp;
+                result = Long.parseLong(concat, 16);
+            }
+            // no change otherwise
+        }
+    )+
+    {
+        return result;
+    }
+}
 
+Long HexDigitOrUnderscore():
+{
+    long value;
+}
+{
+    value=HexDigit() { return value; }
+|
+    "_" { return null; }
+}
 
-long HexIntegerLiteral(): {}{}
 long OctalIntegerLiteral():{}{}
 long BinaryIntegerLiteral():{}{}
 

--- a/src/main/java/main/JavaParser.jj
+++ b/src/main/java/main/JavaParser.jj
@@ -1264,11 +1264,12 @@ Expression PrimaryExpression() :
 LiteralExpressionNode Literal() :
 {
     Token t;
+    LiteralExpressionNode n;
 }
 {
-    (t=<INTEGER_LITERAL>
-|   t=<FLOATING_POINT_LITERAL>
-|   t=<CHARACTER_LITERAL>
+    (n=NumericalLiteral() { return n; })
+|
+    (t=<CHARACTER_LITERAL>
 |   t=<STRING_LITERAL>
 |   t=<TRUE>
 |   t=<FALSE>
@@ -1284,8 +1285,11 @@ LiteralExpressionNode NumericalLiteral():
 { NumericalLiteralNode n; }
 {
     n=IntegerLiteral() { return n; }
-|
+/*|
     n=FloatingPointLiteral() { return n; }
+    When floating point literals are implemented,
+    https://docs.oracle.com/javase/specs/jls/se11/html/jls-3.html#jls-FloatingPointLiteral
+    */
 }
 
 IntegerLiteralNode IntegerLiteral(): // either int or long
@@ -1573,39 +1577,78 @@ Long OctalDigitOrUnderscore():
     "_" { return null; }
 }
 
+// also similar pattern
+long BinaryIntegerLiteral():
+{
+    long value;
+}
+{
+    "0" ["b" "B"] (Underscores())? value=BinaryDigits() { return value; }
+}
 
-// long BinaryIntegerLiteral():{}{}
+long BinaryDigits():
+{
+    long result;
+    long temp;
+    Long temp2;
+    String concat;
+}
+{
+    result=BinaryDigit()
+    (
+        (temp2=BinaryDigitsAndUnderscores() {
+            // concatenate result if not null
+            if (temp2 != null) {
+                concat = "" + result + temp2;
+                result = Long.parseLong(concat, 2);
+            }
+        })?
+        temp=BinaryDigit() { /* concatenate result */ result *= 8; result += temp; }
+    )?
+}
 
-// FloatingPointLiteral FloatingPointLiteral():{}{} // either float or double
+// comsumes a binary digit and returns its value.
+long BinaryDigit():{}
+{
+    "0" { return 0; }
+|   "1" { return 1; }
+}
 
-// FloatingPointLiteral FloatingPointLiteral(): {} {}
-//
+Long BinaryDigitsAndUnderscores():
+{
+    Long result = null;
+    Long temp;
+    String concat;
+}
+{
+    (
+        temp=BinaryDigitOrUnderscore()
+        {
+            if (result == null) {
+                result = temp;
+            } else if (temp != null) {
+                // concatenate
+                concat = "" + result + temp;
+                result = Long.parseLong(concat, 2);
+            }
+            // no change otherwise
+        }
+    )+
+    {
+        return result;
+    }
+}
 
-/**
-  < INTEGER_LITERAL:
-        <DECIMAL_LITERAL> (["l","L"])?
-      | <HEX_LITERAL> (["l","L"])?
-      | <OCTAL_LITERAL> (["l","L"])?
-  >
+
+Long BinaryDigitOrUnderscore():
+{
+    long value;
+}
+{
+    value=BinaryDigit() { return value; }
 |
-  < #DECIMAL_LITERAL: ["1"-"9"] (["0"-"9"])* >
-|
-  < #HEX_LITERAL: "0" ["x","X"] (["0"-"9","a"-"f","A"-"F"])+ >
-|
-  < #OCTAL_LITERAL: "0" (["0"-"7"])* >
-|
-  < FLOATING_POINT_LITERAL:
-        (["0"-"9"])+ "." (["0"-"9"])* (<EXPONENT>)? (["f","F","d","D"])?
-      | "." (["0"-"9"])+ (<EXPONENT>)? (["f","F","d","D"])?
-      | (["0"-"9"])+ <EXPONENT> (["f","F","d","D"])?
-      | (["0"-"9"])+ (<EXPONENT>)? ["f","F","d","D"]
-  >
-|
-  < #EXPONENT: ["e","E"] (["+","-"])? (["0"-"9"])+ >
-
-*/
-
-
+    "_" { return null; }
+}
 
 
 ArrayList<Expression> Arguments() :

--- a/src/main/java/tree/ArrayAllocationNode.java
+++ b/src/main/java/tree/ArrayAllocationNode.java
@@ -1,10 +1,15 @@
 package tree;
 
-import helper.*;
+import conversions.Conversion;
+import helper.ClassLookup;
+import helper.CompileException;
+import helper.ConditionCode;
+import helper.Types;
 import intermediate.*;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import static helper.BinaryOperation.ADD;
 
@@ -68,7 +73,18 @@ public class ArrayAllocationNode extends NodeImpl implements Expression {
 				break;
 			}
 			first.compile(s, f);
-			sizes.add(f.allocator.getLast());
+			Register size = f.allocator.getLast();
+			// convert to int
+			Register sizeInt = f.allocator.getNext(Types.INT);
+
+			// assignment conversion from potentially smaller to int.
+			List<InterStatement> conversion = Conversion.assignmentConversion(size, sizeInt, getFileName(), getLine());
+
+			for (InterStatement st : conversion) {
+				f.addStatement(st);
+			}
+
+			sizes.add(sizeInt);
 			elementType = elementType.removeArray(getFileName(), getLine());
 		}
 

--- a/src/main/java/tree/BinaryExpressionNode.java
+++ b/src/main/java/tree/BinaryExpressionNode.java
@@ -38,7 +38,7 @@ public class BinaryExpressionNode extends NodeImpl implements Expression {
 
 		// perform the binary operation on the 2
 		Register destination = f.allocator.getNext(
-			leftResult.getType().getLarger(rightResult.getType()));
+			leftResult.getType().getResult(rightResult.getType()));
 
 		f.addStatement(new BinaryOpStatement(
 			leftResult, rightResult,

--- a/src/main/resources/test-programs/IntegerLiterals.java
+++ b/src/main/resources/test-programs/IntegerLiterals.java
@@ -1,0 +1,18 @@
+
+public class IntegerLiterals {
+
+	public static void main(String[] args) {
+		System.out.println(0x10); // 16
+		System.out.println(020); // 16
+		System.out.println(16);
+		System.out.println(16L);
+		System.out.println(0b10000);
+
+		// also with underscores
+		System.out.println(0x1__0); // 16
+		System.out.println(0_2_0); // 16
+		System.out.println(1___6);
+		System.out.println(1_6L);
+		System.out.println(0b1__0000);
+	}
+}

--- a/src/test/java/main/TestCompiler.java
+++ b/src/test/java/main/TestCompiler.java
@@ -74,7 +74,8 @@ class TestCompiler extends ScenarioTest<GivenInputProgram, WhenItCompilesAndRuns
             Arguments.of("SimpleArray", "[1, 1, 2, 3, 5, 8, 13, 21, 34, 55]\n", ""),
             Arguments.of("ArrayLength", "143\n", ""),
             Arguments.of("TwoDimensionArray", "[X, O, O]\n[O, X, O]\n[O, O, X]\n", ""),
-            Arguments.of("JaggedArray", "[0]\n[0, 0]\n[0, 0, 0]\n[0, 0, 0, 0]\n", "")
+            Arguments.of("JaggedArray", "[0]\n[0, 0]\n[0, 0, 0]\n[0, 0, 0, 0]\n", ""),
+            Arguments.of("IntegerLiterals", "16\n16\n16\n16\n16\n16\n16\n16\n16\n16\n", "")
         );
     }
 


### PR DESCRIPTION
Resolves #48, underscores in integers are now allowed.
This was a new language feature in java 1.7
Underscores are only allowed between digits, which is part of the Java Language Specification

In addition, this implements integer literals of bases 2, 8, and 16. Base 10 was already in the code.